### PR TITLE
Add cron trigger to functional tests

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -6,6 +6,10 @@ on: # yamllint disable-line rule:truthy
     branches:
       - "main"
   pull_request:
+    branches:
+      - "main"
+  schedule:
+    - cron: "0 0 * * 1"
 
 defaults:
   run:


### PR DESCRIPTION
Add cron trigger to functional tests to be sure that "latest" works as expected.